### PR TITLE
➕ Endpoint resolving omnibus balances

### DIFF
--- a/external/getAssetInfo.py
+++ b/external/getAssetInfo.py
@@ -1,6 +1,8 @@
 import boto3, json, requests, toml
 from decimal import Decimal
 
+LEGACY_DB = boto3.resource("dynamodb").Table("legacy")
+
 def lambda_handler(event, context):
   code = event["pathParameters"].get("code").upper()
   if code.isdigit():
@@ -11,6 +13,8 @@ def lambda_handler(event, context):
     return {
       "statusCode": 200,
       "body": json.dumps({
+        # check/output here or in function the Distributor.xlm bal
+        "legacy": getInternalDistributor(code)
         "outstanding": getNumOutstanding(code)
       })
     }
@@ -23,6 +27,10 @@ def lambda_handler(event, context):
         "usage": "https://api.blocktransfer.com/assets/{CIK}"
       })
     }
+
+def getInternalDistributor(code):
+  totalLegacyHeld = {scan(LEGACY_DB)} TODO
+  return totalLegacyHeld
 
 def getNumOutstanding(code):
   try:


### PR DESCRIPTION
This closes #3 using the mentioned shared endpoint, which adds an internal database call. It's a query on the asset code, which adds more to runtime than a static check, but not significantly more than the Horizon outstanding request. Depending on how we do the `distributor.xlm` check, we could hit 3 calls.
